### PR TITLE
Increase battery charge current from 50mA to 100mA

### DIFF
--- a/boards/shields/ergonaut_one/ergonaut_one.dtsi
+++ b/boards/shields/ergonaut_one/ergonaut_one.dtsi
@@ -54,3 +54,12 @@
 &xiao_spi { status = "disabled"; };
 &xiao_i2c { status = "disabled"; };
 &xiao_serial { status = "disabled"; };
+
+&gpio0 {
+    fastbatcharge: fast-battery-charge {
+        gpio-hog;
+        gpios = <13 GPIO_ACTIVE_HIGH>;
+        output-low;
+        line-name = "Fast Battery Charge";
+    };
+};


### PR DESCRIPTION
This is a port of https://github.com/ergonautkb/one-zmk-config/pull/6 to a ZMK module.
Was originally authored by @proostas

>By default, the charging IC in Xiao BLE uses 50mA current, which is too slow. But there is a way to make it charge with 100mA. In case of 250mAh battery, 100mA is only 0.4C, which is safe for the batteries.
This PR enables 100mA charging current.
